### PR TITLE
2 fix include folder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,26 +1,22 @@
-[project]
+[tool.poetry]
 name = "cpp-proj-maker"
 version = "0.1.0"
 description = "A CPP/CMake project creator"
-authors = [
-    {name = "Gabriel Valderramos"}
-]
-license = {text = "MIT"}
+authors = ["Gabriel Valderramos"]
+license = "MIT"
 readme = "README.md"
-requires-python = ">=3.10,<3.15"
-dependencies = [
-    "jinja2 (>=3.1.6,<4.0.0)",
-    "inquirerpy (>=0.3.4,<0.4.0)",
-    "pytest (>=9.0.2,<10.0.0)",
-    "pyinstaller (>=6.18.0,<7.0.0)"
-]
+packages = [{ include = "cpp_proj_maker", from = "src" }]
 
-[tool.poetry]
-packages = [{include = "cpp_proj_maker", from = "src"}]
+[tool.poetry.dependencies]
+python = ">=3.10,<3.15"
+jinja2 = "^3.1"
+inquirerpy = "^0.3"
+pytest = "^9.0"
+pyinstaller = "^6.18"
+
+[tool.poetry.scripts]
+cpp-proj-maker = "cpp_proj_maker.main:main"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.poetry.scripts]
-cpp-proj-maker = "cpp_proj_maker.main:main"

--- a/src/cpp_proj_maker/templates/main_cmake.txt
+++ b/src/cpp_proj_maker/templates/main_cmake.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.25)
 project({{name}} VERSION {{version}})
 
 set(CMAKE_CXX_STANDARD {{cpp_standard}})
+{% if common_libraries %}
+include_directories("${CMAKE_SOURCE_DIR}/include")
+{% endif %}
 
 add_subdirectory(src)
 {% if has_tests %}

--- a/src/cpp_proj_maker/templates/main_cmake.txt
+++ b/src/cpp_proj_maker/templates/main_cmake.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.25)
 project({{name}} VERSION {{version}})
 
 set(CMAKE_CXX_STANDARD {{cpp_standard}})
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 {% if common_libraries %}
 include_directories("${CMAKE_SOURCE_DIR}/include")
 {% endif %}

--- a/src/cpp_proj_maker/templates/tests_cmake.txt
+++ b/src/cpp_proj_maker/templates/tests_cmake.txt
@@ -15,6 +15,7 @@ add_executable({{ name }}-tests
 target_link_libraries({{ name }}-tests
     PRIVATE
         gtest gtest_main
+        {%if libraries %}{{ libraries | join(' ') }}{%endif%} 
 )
 target_include_directories({{ name }}-tests
     PRIVATE


### PR DESCRIPTION
## Description
I added the include folder on main cmake file and I took advantage to add some things related with that, for instance I got an error to build the poetry on Linux and I realized that the poetry is requiring the authors, description and version name. To not duplicate this info I also removed that from the project and kept just on poetry config.
I also saw that the cmake responsible for unit testing was not linking when we have libraries, that is important to test it.

## Related Issue
Fixes #2 

## Checklist
- [x] Tests pass
- [x] Documentation updated
- [x] Code follows style guide   